### PR TITLE
Allow auto-tagging to trigger releases

### DIFF
--- a/.github/workflows/step-tag-release.yml
+++ b/.github/workflows/step-tag-release.yml
@@ -13,6 +13,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Create tag
+        env:
+          GH_TOKEN: ${{ secrets.CREATE_TAG_TOKEN }}
         run: |
           git config --global user.name "GitHub Action Bot"
           git config --global user.email "no-reply@after-life.co"


### PR DESCRIPTION
Workflows cannot trigger other workflows unless you use
a PAT.

https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow

Fixes #47
